### PR TITLE
Rename mix app from `pay_nl` to `paynl`

### DIFF
--- a/lib/pay_nl/options.ex
+++ b/lib/pay_nl/options.ex
@@ -101,7 +101,7 @@ defmodule PayNL.Options do
        )
     |> validate_required(
          :service_id,
-         message: ~s[has not been set, either pass it along with the params in this function as :service_id, alternatively you can pass it by defining an env var 'PAY_NL_SERVICE_ID=my_service_id' or in you config add 'config :pay_nl, api_token: "my_service_id"']
+         message: ~s[has not been set, either pass it along with the params in this function as :service_id, alternatively you can pass it by defining an env var 'PAY_NL_SERVICE_ID=my_service_id' or in you config add 'config :pay_nl, service_id: "my_service_id"']
        )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PayNL.Mixfile do
 
   def project do
     [
-      app: :pay_nl,
+      app: :paynl,
       version: "0.1.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
When including and starting this package in an Elixir project, this warning was shown:

```
Unchecked dependencies for environment dev:
* paynl (https://github.com/smeevil/paynl.git)
  could not find an app file at "_build/dev/lib/paynl/ebin/paynl.app". This may happen if the dependency was not yet compiled, or you specified the wrong application name in your deps, or the dependency indeed has no app file (then you can pass app: false as option)
** (Mix) Can't continue due to errors on dependencies
```

This PR should fix that.